### PR TITLE
Rename fix Spryker class naming

### DIFF
--- a/src/Flagbit/Zed/SprykerSmartInboxConnector/Business/SchemaOrgOrderMailExpander/SchemaOrgOrderMailExpander.php
+++ b/src/Flagbit/Zed/SprykerSmartInboxConnector/Business/SchemaOrgOrderMailExpander/SchemaOrgOrderMailExpander.php
@@ -3,8 +3,8 @@
 namespace Flagbit\Zed\SprykerSmartInboxConnector\Business\SchemaOrgOrderMailExpander;
 
 use Flagbit\Zed\SprykerSmartInboxConnector\Business\ParcelDelivery\ParcelDeliveryFactory;
-use Flagbit\Zed\SprykerSmartInboxConnector\OneAndOneMailConnectorConfig;
-use Flagbit\Zed\SprykerSmartInboxConnector\Persistence\OneAndOneMailConnectorRepositoryInterface;
+use Flagbit\Zed\SprykerSmartInboxConnector\Persistence\SprykerSmartInboxConnectorRepositoryInterface;
+use Flagbit\Zed\SprykerSmartInboxConnector\SprykerSmartInboxConnectorConfig;
 use Generated\Shared\Transfer\ItemTransfer;
 use Generated\Shared\Transfer\MailTemplateTransfer;
 use Generated\Shared\Transfer\MailTransfer;
@@ -15,12 +15,12 @@ use Generated\Shared\Transfer\SchemaOrgTransfer;
 class SchemaOrgOrderMailExpander implements SchemaOrgOrderMailExpanderInterface
 {
     /**
-     * @var \Flagbit\Zed\SprykerSmartInboxConnector\OneAndOneMailConnectorConfig
+     * @var \Flagbit\Zed\SprykerSmartInboxConnector\SprykerSmartInboxConnectorConfig
      */
     private $config;
 
     /**
-     * @var \Flagbit\Zed\SprykerSmartInboxConnector\Persistence\OneAndOneMailConnectorRepositoryInterface
+     * @var \Flagbit\Zed\SprykerSmartInboxConnector\Persistence\SprykerSmartInboxConnectorRepositoryInterface
      */
     private $repository;
 
@@ -30,13 +30,13 @@ class SchemaOrgOrderMailExpander implements SchemaOrgOrderMailExpanderInterface
     private $parcelDeliveryFactory;
 
     /**
-     * @param \Flagbit\Zed\SprykerSmartInboxConnector\OneAndOneMailConnectorConfig $config
-     * @param \Flagbit\Zed\SprykerSmartInboxConnector\Persistence\OneAndOneMailConnectorRepositoryInterface $repository
+     * @param \Flagbit\Zed\SprykerSmartInboxConnector\SprykerSmartInboxConnectorConfig $config
+     * @param \Flagbit\Zed\SprykerSmartInboxConnector\Persistence\SprykerSmartInboxConnectorRepositoryInterface $repository
      * @param \Flagbit\Zed\SprykerSmartInboxConnector\Business\ParcelDelivery\ParcelDeliveryFactory $parcelDeliveryFactory
      */
     public function __construct(
-        OneAndOneMailConnectorConfig $config,
-        OneAndOneMailConnectorRepositoryInterface $repository,
+        SprykerSmartInboxConnectorConfig $config,
+        SprykerSmartInboxConnectorRepositoryInterface $repository,
         ParcelDeliveryFactory $parcelDeliveryFactory
     ) {
         $this->config = $config;
@@ -105,7 +105,7 @@ class SchemaOrgOrderMailExpander implements SchemaOrgOrderMailExpanderInterface
     protected function fillMailTemplateInfos(MailTemplateTransfer $mailTemplateTransfer): MailTemplateTransfer
     {
         $mailTemplateTransfer->setIsHtml(true);
-        $mailTemplateTransfer->setName('sprykerSmartInboxConnector/mail/schema_org_order_connector.html.twig');
+        $mailTemplateTransfer->setName('Flagbit:SprykerSmartInboxConnector/mail/schema_org_order_connector.html.twig');
 
         return $mailTemplateTransfer;
     }

--- a/src/Flagbit/Zed/SprykerSmartInboxConnector/Business/SprykerSmartInboxConnectorBusinessFactory.php
+++ b/src/Flagbit/Zed/SprykerSmartInboxConnector/Business/SprykerSmartInboxConnectorBusinessFactory.php
@@ -10,10 +10,10 @@ use Generated\Shared\Transfer\SchemaOrgTransfer;
 use Spryker\Zed\Kernel\Business\AbstractBusinessFactory;
 
 /**
- * @method \Flagbit\Zed\SprykerSmartInboxConnector\OneAndOneMailConnectorConfig getConfig()
- * @method \Flagbit\Zed\SprykerSmartInboxConnector\Persistence\OneAndOneMailConnectorRepositoryInterface getRepository()
+ * @method \Flagbit\Zed\SprykerSmartInboxConnector\SprykerSmartInboxConnectorConfig getConfig()
+ * @method \Flagbit\Zed\SprykerSmartInboxConnector\Persistence\SprykerSmartInboxConnectorRepositoryInterface getRepository()
  */
-class OneAndOneMailConnectorBusinessFactory extends AbstractBusinessFactory
+class SprykerSmartInboxConnectorBusinessFactory extends AbstractBusinessFactory
 {
     /**
      * @return \Flagbit\Zed\SprykerSmartInboxConnector\Business\SchemaOrgOrderMailExpander\SchemaOrgOrderMailExpanderInterface

--- a/src/Flagbit/Zed/SprykerSmartInboxConnector/Business/SprykerSmartInboxConnectorFacade.php
+++ b/src/Flagbit/Zed/SprykerSmartInboxConnector/Business/SprykerSmartInboxConnectorFacade.php
@@ -7,10 +7,10 @@ use Generated\Shared\Transfer\OrderTransfer;
 use Spryker\Zed\Kernel\Business\AbstractFacade;
 
 /**
- * @method \Flagbit\Zed\SprykerSmartInboxConnector\Business\OneAndOneMailConnectorBusinessFactory getFactory()
- * @method \Flagbit\Zed\SprykerSmartInboxConnector\Persistence\OneAndOneMailConnectorRepositoryInterface getRepository()
+ * @method \Flagbit\Zed\SprykerSmartInboxConnector\Business\SprykerSmartInboxConnectorBusinessFactory getFactory()
+ * @method \Flagbit\Zed\SprykerSmartInboxConnector\Persistence\SprykerSmartInboxConnectorRepositoryInterface getRepository()
  */
-class OneAndOneMailConnectorFacade extends AbstractFacade implements OneAndOneMailConnectorFacadeInterface
+class SprykerSmartInboxConnectorFacade extends AbstractFacade implements SprykerSmartInboxConnectorFacadeInterface
 {
     /**
      * @param \Generated\Shared\Transfer\MailTransfer $mailTransfer

--- a/src/Flagbit/Zed/SprykerSmartInboxConnector/Business/SprykerSmartInboxConnectorFacadeInterface.php
+++ b/src/Flagbit/Zed/SprykerSmartInboxConnector/Business/SprykerSmartInboxConnectorFacadeInterface.php
@@ -5,7 +5,7 @@ namespace Flagbit\Zed\SprykerSmartInboxConnector\Business;
 use Generated\Shared\Transfer\MailTransfer;
 use Generated\Shared\Transfer\OrderTransfer;
 
-interface OneAndOneMailConnectorFacadeInterface
+interface SprykerSmartInboxConnectorFacadeInterface
 {
     /**
      * @param \Generated\Shared\Transfer\MailTransfer $mailTransfer

--- a/src/Flagbit/Zed/SprykerSmartInboxConnector/Communication/Plugin/OneAndOneMailConnectorOrderMailExpanderPlugin.php
+++ b/src/Flagbit/Zed/SprykerSmartInboxConnector/Communication/Plugin/OneAndOneMailConnectorOrderMailExpanderPlugin.php
@@ -8,13 +8,13 @@ use Spryker\Zed\Kernel\Communication\AbstractPlugin;
 use Spryker\Zed\OmsExtension\Dependency\Plugin\OmsOrderMailExpanderPluginInterface;
 
 /**
- * @method \Flagbit\Zed\SprykerSmartInboxConnector\Business\OneAndOneMailConnectorFacade getFacade()
- * @method \Flagbit\Zed\SprykerSmartInboxConnector\OneAndOneMailConnectorConfig getConfig()
+ * @method \Flagbit\Zed\SprykerSmartInboxConnector\Business\SprykerSmartInboxConnectorFacade getFacade()
+ * @method \Flagbit\Zed\SprykerSmartInboxConnector\SprykerSmartInboxConnectorConfig getConfig()
  */
 class OneAndOneMailConnectorOrderMailExpanderPlugin extends AbstractPlugin implements OmsOrderMailExpanderPluginInterface
 {
     /**
-     * @method \Flagbit\Zed\SprykerSmartInboxConnector\Business\OneAndOneMailConnectorFacade getFacade()
+     * @method \Flagbit\Zed\SprykerSmartInboxConnector\Business\SprykerSmartInboxConnectorFacade getFacade()
      *
      * @param \Generated\Shared\Transfer\MailTransfer $mailTransfer
      * @param \Generated\Shared\Transfer\OrderTransfer $orderTransfer

--- a/src/Flagbit/Zed/SprykerSmartInboxConnector/Persistence/SprykerSmartInboxConnectorPersistenceFactory.php
+++ b/src/Flagbit/Zed/SprykerSmartInboxConnector/Persistence/SprykerSmartInboxConnectorPersistenceFactory.php
@@ -6,10 +6,10 @@ use Orm\Zed\Sales\Persistence\SpySalesOrderItemQuery;
 use Spryker\Zed\Kernel\Persistence\AbstractPersistenceFactory;
 
 /**
- * @method \Flagbit\Zed\SprykerSmartInboxConnector\OneAndOneMailConnectorConfig getConfig()
- * @method \Flagbit\Zed\SprykerSmartInboxConnector\Persistence\OneAndOneMailConnectorRepositoryInterface getRepository()
+ * @method \Flagbit\Zed\SprykerSmartInboxConnector\SprykerSmartInboxConnectorConfig getConfig()
+ * @method \Flagbit\Zed\SprykerSmartInboxConnector\Persistence\SprykerSmartInboxConnectorRepositoryInterface getRepository()
  */
-class OneAndOneMailConnectorPersistenceFactory extends AbstractPersistenceFactory
+class SprykerSmartInboxConnectorPersistenceFactory extends AbstractPersistenceFactory
 {
     /**
      * @return \Orm\Zed\Sales\Persistence\SpySalesOrderItemQuery

--- a/src/Flagbit/Zed/SprykerSmartInboxConnector/Persistence/SprykerSmartInboxConnectorRepository.php
+++ b/src/Flagbit/Zed/SprykerSmartInboxConnector/Persistence/SprykerSmartInboxConnectorRepository.php
@@ -6,9 +6,9 @@ use Propel\Runtime\ActiveQuery\Criteria;
 use Spryker\Zed\Kernel\Persistence\AbstractRepository;
 
 /**
- * @method \Flagbit\Zed\SprykerSmartInboxConnector\Persistence\OneAndOneMailConnectorPersistenceFactory getFactory()
+ * @method \Flagbit\Zed\SprykerSmartInboxConnector\Persistence\SprykerSmartInboxConnectorPersistenceFactory getFactory()
  */
-class OneAndOneMailConnectorRepository extends AbstractRepository implements OneAndOneMailConnectorRepositoryInterface
+class SprykerSmartInboxConnectorRepository extends AbstractRepository implements SprykerSmartInboxConnectorRepositoryInterface
 {
     /**
      * @param array $idOrderItems

--- a/src/Flagbit/Zed/SprykerSmartInboxConnector/Persistence/SprykerSmartInboxConnectorRepositoryInterface.php
+++ b/src/Flagbit/Zed/SprykerSmartInboxConnector/Persistence/SprykerSmartInboxConnectorRepositoryInterface.php
@@ -2,7 +2,7 @@
 
 namespace Flagbit\Zed\SprykerSmartInboxConnector\Persistence;
 
-interface OneAndOneMailConnectorRepositoryInterface
+interface SprykerSmartInboxConnectorRepositoryInterface
 {
     /**
      * @param array $idOrderItems

--- a/src/Flagbit/Zed/SprykerSmartInboxConnector/SprykerSmartInboxConnectorConfig.php
+++ b/src/Flagbit/Zed/SprykerSmartInboxConnector/SprykerSmartInboxConnectorConfig.php
@@ -5,7 +5,7 @@ namespace Flagbit\Zed\SprykerSmartInboxConnector;
 use Flagbit\Shared\SprykerSmartInboxConnector\OneAndOneMailConnectorConstants;
 use Spryker\Zed\Kernel\AbstractBundleConfig;
 
-class OneAndOneMailConnectorConfig extends AbstractBundleConfig
+class SprykerSmartInboxConnectorConfig extends AbstractBundleConfig
 {
     /**
      * @return string

--- a/tests/FlagbitTest/Zed/SprykerSmartInboxConnector/_support/OneAndOneMailConnectorBusinessTester.php
+++ b/tests/FlagbitTest/Zed/SprykerSmartInboxConnector/_support/OneAndOneMailConnectorBusinessTester.php
@@ -5,8 +5,8 @@ namespace FlagbitTest\Zed\SprykerSmartInboxConnector;
 use Codeception\Actor;
 use Codeception\Test\Unit;
 use Flagbit\Zed\SprykerSmartInboxConnector\Business\ParcelDelivery\ParcelDeliveryFactory;
-use Flagbit\Zed\SprykerSmartInboxConnector\OneAndOneMailConnectorConfig;
-use Flagbit\Zed\SprykerSmartInboxConnector\Persistence\OneAndOneMailConnectorRepository;
+use Flagbit\Zed\SprykerSmartInboxConnector\Persistence\SprykerSmartInboxConnectorRepository;
+use Flagbit\Zed\SprykerSmartInboxConnector\SprykerSmartInboxConnectorConfig;
 use Generated\Shared\Transfer\ItemStateTransfer;
 use Generated\Shared\Transfer\ItemTransfer;
 use Generated\Shared\Transfer\MailTemplateTransfer;
@@ -43,11 +43,11 @@ class OneAndOneMailConnectorBusinessTester extends Actor
      * @param array $statusMatrix
      * @param string $shopName
      *
-     * @return \Flagbit\Zed\SprykerSmartInboxConnector\OneAndOneMailConnectorConfig|\PHPUnit\Framework\MockObject\MockObject
+     * @return \Flagbit\Zed\SprykerSmartInboxConnector\SprykerSmartInboxConnectorConfig|\PHPUnit\Framework\MockObject\MockObject
      */
-    public function createConfigMock(Unit $unit, array $statusMatrix, string $shopName): OneAndOneMailConnectorConfig
+    public function createConfigMock(Unit $unit, array $statusMatrix, string $shopName): SprykerSmartInboxConnectorConfig
     {
-        $config = $unit->getMockBuilder(OneAndOneMailConnectorConfig::class)
+        $config = $unit->getMockBuilder(SprykerSmartInboxConnectorConfig::class)
             ->disableOriginalConstructor()
             ->getMock();
         $config->method('getShopName')
@@ -77,7 +77,7 @@ class OneAndOneMailConnectorBusinessTester extends Actor
         $mailTemplateTransfer->method('setIsHtml')
             ->with(true);
         $mailTemplateTransfer->method('setName')
-            ->with('sprykerSmartInboxConnector/mail/schema_org_order_connector.html.twig');
+            ->with('Flagbit:SprykerSmartInboxConnector/mail/schema_org_order_connector.html.twig');
 
         return $mailTemplateTransfer;
     }
@@ -213,14 +213,14 @@ class OneAndOneMailConnectorBusinessTester extends Actor
      * @param array $itemValues
      * @param \Orm\Zed\Sales\Persistence\SpySalesOrderItem $orderCollection
      *
-     * @return \Flagbit\Zed\SprykerSmartInboxConnector\Persistence\OneAndOneMailConnectorRepository|\PHPUnit\Framework\MockObject\MockObject
+     * @return \Flagbit\Zed\SprykerSmartInboxConnector\Persistence\SprykerSmartInboxConnectorRepository|\PHPUnit\Framework\MockObject\MockObject
      */
     public function createRepositoryMock(
         Unit $unit,
         array $itemValues,
         SpySalesOrderItem $orderCollection
-    ): OneAndOneMailConnectorRepository {
-        $repository = $unit->getMockBuilder(OneAndOneMailConnectorRepository::class)
+    ): SprykerSmartInboxConnectorRepository {
+        $repository = $unit->getMockBuilder(SprykerSmartInboxConnectorRepository::class)
             ->disableOriginalConstructor()
             ->getMock();
         $repository->method('findSpySalesOrderItemByIdWithLastStateChange')


### PR DESCRIPTION
Some classes/templates should be renamed since they are loaded by Spryker module naming convention. I've tested this on our demo and seems to be working. It can be tested with the demo shop repo (https://github.com/flagbit/spryker-b2c-demo-shop/tree/renaming_spryker_classes) if desired.